### PR TITLE
OMNI-2126: JS error on adv listing page on safari

### DIFF
--- a/src/services/builder.js
+++ b/src/services/builder.js
@@ -117,7 +117,7 @@ angular.module('schemaForm').provider('sfBuilder', ['sfPathProvider', function(s
     oneOfTransclusion: function(args) {
       var transclusions = args.fieldFrag.querySelectorAll('[sf-field-oneof-transclude]');
 
-      transclusions.forEach(function(transclusion) {
+      angular.forEach(transclusions, function(transclusion) {
         var sub = transclusion.getAttribute('sf-field-oneof-transclude') || 'items';
         var items = args.form[sub] || [];
         var modelValue = 'selectors' + sfPathProvider.stringify(args.form.key).replace(/"/g, '&quot;');


### PR DESCRIPTION
# What ?
- Fixes an error where safari crashes on the advanced listing page for Safari < 9
# Why ?
- The function `forEach` is not defined on the `NodeList` prototype in Safari
# Testing done
- Verified Safari does not crash

@deini @bc-ninablanson 
